### PR TITLE
UBI JRE Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ The public image is available but you can build your own image wtih:
 ```sh
 mvn clean package docker:build
 ```
+Manually publish updates to Bintray.
 
 ## Openshift
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ make a Route to deployment/akka-cluster-demo port 8080 for the UI
 
 ## Minikube
 
-Install the AkkaCluster Operator.
+Install the AkkaCluster Operator from [OperatorHub.io](https://operatorhub.io/operator/akka-cluster-operator) before deploying the demo application.
 
 ```bash
 kubectl apply -f ./kubernetes/akka-cluster-minishift.yml

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ We've only removed a few config
 options so they go back to defaults, and updated Akka Mangement to 1.0, and then specify the app with an
 AkkaCluster resource instead of Namespace + Role + Rolebinding against default account + Deployment.
 
-The AkkaCluster resource can be installed in any namespace.
+The AkkaCluster resource can be installed in any namespace. This application uses the Red Hat Universal Base Image([UBI](https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image])), and the [AdoptOpenJDK](https://adoptopenjdk.net/.).
 
 ## Enable Akka Management
 
@@ -22,7 +22,9 @@ akka.management {
 ```
 ## Install the AkkaCluster operator
 
-To install the operator, use [OperatorHub.io](https://operatorhub.io) or clone the Operator repo and follow its README. It is pre-built so you're just loading
+To install the operator, use the [Akka Cluster Operator](https://operatorhub.io/operator/akka-cluster-operator) from [OperatorHub.io](https://operatorhub.io).
+
+You can also clone the Operator repo and follow its README. It is pre-built so you're just loading
 Kubernetes resources in this step and using the bintray image.
 
 https://github.com/lightbend/akka-cluster-operator

--- a/kubernetes/akka-cluster-minikube.yml
+++ b/kubernetes/akka-cluster-minikube.yml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: main
-        image: lightbend-docker-registry.bintray.io/lightbend/akka-cluster-demo:1.0.2
+        image: lightbend-docker-registry.bintray.io/lightbend/akka-cluster-demo:1.1.0
         livenessProbe:
           tcpSocket:
             port: 8558

--- a/kubernetes/akka-cluster.yml
+++ b/kubernetes/akka-cluster.yml
@@ -8,7 +8,7 @@ spec:
     spec:
       containers:
       - name: main
-        image: lightbend-docker-registry.bintray.io/lightbend/akka-cluster-demo:1.0.2
+        image: lightbend-docker-registry.bintray.io/lightbend/akka-cluster-demo:1.1.0
         readinessProbe:
           httpGet:
             path: "/ready"

--- a/pom.xml
+++ b/pom.xml
@@ -3,14 +3,14 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>akka-java</groupId>
     <artifactId>akka-cluster-openshift</artifactId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
     <properties>
         <java.version>8</java.version>
         <scala.version>2.12</scala.version>
-        <akka.version>2.5.22</akka.version>
-        <akka.http.version>10.1.7</akka.http.version>
-        <akka.cluster.bootstrap.version>1.0.0</akka.cluster.bootstrap.version>
-        <docker.image.version>1.0.2</docker.image.version>
+        <akka.version>2.5.29</akka.version>
+        <akka.http.version>10.1.11</akka.http.version>
+        <akka.cluster.bootstrap.version>1.0.5</akka.cluster.bootstrap.version>
+        <docker.image.version>1.1.0</docker.image.version>
         <jackson.version>2.9.8</jackson.version>
         <junit.version>4.12</junit.version>
         <junit.jupiter.version>5.0.2</junit.jupiter.version>
@@ -180,13 +180,13 @@
             <plugin>
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.27.2</version>
+                <version>0.33.0</version>
                 <configuration>
                     <images>
                         <image>
                             <name>akka-cluster-demo:${docker.image.version}</name>
                             <build>
-                                <from>openjdk:8-jre-alpine</from>
+                                <dockerFileDir>ubi-jre</dockerFileDir>
                                 <ports>
                                     <port>8080</port>
                                     <port>8558</port>

--- a/src/main/docker/ubi-jre/Dockerfile
+++ b/src/main/docker/ubi-jre/Dockerfile
@@ -4,9 +4,9 @@ LABEL maintainer="Lightbend, Inc"
 # Update image
 RUN yum update --disableplugin=subscription-manager -y && rm -rf /var/cache/yum
 
-# Install OpenJDK 
+# Install OpenJDK
 COPY adoptopenjdk.repo /etc/yum.repos.d/adoptopenjdk.repo
-RUN yum update --disableplugin=subscription-manager -y && rm -rf /var/cache/yum 
+RUN yum update --disableplugin=subscription-manager -y && rm -rf /var/cache/yum
 RUN yum install -y adoptopenjdk-8-hotspot-jre
 
 # Add Lightbend User

--- a/src/main/docker/ubi-jre/Dockerfile
+++ b/src/main/docker/ubi-jre/Dockerfile
@@ -1,0 +1,13 @@
+FROM registry.access.redhat.com/ubi8/ubi
+LABEL maintainer="Lightbend, Inc"
+
+# Update image
+RUN yum update --disableplugin=subscription-manager -y && rm -rf /var/cache/yum
+
+# Install OpenJDK 
+COPY adoptopenjdk.repo /etc/yum.repos.d/adoptopenjdk.repo
+RUN yum update --disableplugin=subscription-manager -y && rm -rf /var/cache/yum 
+RUN yum install -y adoptopenjdk-8-hotspot-jre
+
+# Add Lightbend User
+RUN useradd -r -m -u 1001 -g 0 lightbenduser

--- a/src/main/docker/ubi-jre/Dockerfile
+++ b/src/main/docker/ubi-jre/Dockerfile
@@ -1,5 +1,9 @@
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi8/ubi:latest
 LABEL maintainer="Lightbend, Inc"
+
+# Certified image
+RUN  mkdir /licenses
+COPY LICENSE /licenses
 
 # Update image
 RUN yum update --disableplugin=subscription-manager -y && rm -rf /var/cache/yum
@@ -7,7 +11,14 @@ RUN yum update --disableplugin=subscription-manager -y && rm -rf /var/cache/yum
 # Install OpenJDK
 COPY adoptopenjdk.repo /etc/yum.repos.d/adoptopenjdk.repo
 RUN yum update --disableplugin=subscription-manager -y && rm -rf /var/cache/yum
-RUN yum install -y adoptopenjdk-8-hotspot-jre
+RUN yum install -y adoptopenjdk-8-hotspot-jre && yum clean all -y
 
-# Add Lightbend User
+EXPOSE 8080 8558 2552
+
+# Add Lightbend User and permit to access 
 RUN useradd -r -m -u 1001 -g 0 lightbenduser
+COPY maven /maven/
+RUN chgrp -R 0 /maven && chmod -R g=u /maven
+ENTRYPOINT ["/bin/sh","-c","java -jar /maven/akka-cluster-openshift.jar"]
+
+USER 1001

--- a/src/main/docker/ubi-jre/Dockerfile
+++ b/src/main/docker/ubi-jre/Dockerfile
@@ -1,7 +1,15 @@
 FROM registry.access.redhat.com/ubi8/ubi:latest
 LABEL maintainer="Lightbend, Inc"
 
-# Certified image
+### Required OpenShift Certified Labels
+LABEL name="Akka Cluster Operator Demo Application" \
+      vendor="Lightbend, Inc." \
+      version="v1.1.0" \
+      release="1.1.0" \
+      summary="Sample Akka Cluster application." \
+      description="Sample of [Akka Cluster](https://doc.akka.io/docs/akka/current/common/cluster.html) and the [Akka Cluster Operator](https://operatorhub.io/operator/akka-cluster-operator)."
+
+# Certified image spec
 RUN  mkdir /licenses
 COPY LICENSE /licenses
 
@@ -13,6 +21,7 @@ COPY adoptopenjdk.repo /etc/yum.repos.d/adoptopenjdk.repo
 RUN yum update --disableplugin=subscription-manager -y && rm -rf /var/cache/yum
 RUN yum install -y adoptopenjdk-8-hotspot-jre && yum clean all -y
 
+# http, management, remoting
 EXPOSE 8080 8558 2552
 
 # Add Lightbend User and permit to access 
@@ -21,4 +30,5 @@ COPY maven /maven/
 RUN chgrp -R 0 /maven && chmod -R g=u /maven
 ENTRYPOINT ["/bin/sh","-c","java -jar /maven/akka-cluster-openshift.jar"]
 
+# See also: https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html
 USER 1001

--- a/src/main/docker/ubi-jre/Dockerfile
+++ b/src/main/docker/ubi-jre/Dockerfile
@@ -32,3 +32,4 @@ ENTRYPOINT ["/bin/sh","-c","java -jar /maven/akka-cluster-openshift.jar"]
 
 # See also: https://docs.openshift.com/container-platform/3.11/creating_images/guidelines.html
 USER 1001
+

--- a/src/main/docker/ubi-jre/LICENSE
+++ b/src/main/docker/ubi-jre/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2019 Lightbend, Inc.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/src/main/docker/ubi-jre/adoptopenjdk.repo
+++ b/src/main/docker/ubi-jre/adoptopenjdk.repo
@@ -1,0 +1,6 @@
+[AdoptOpenJDK]
+name=AdoptOpenJDK
+baseurl=https://adoptopenjdk.jfrog.io/adoptopenjdk/rpm/rhel/8/x86_64
+enabled=1
+gpgcheck=1
+gpgkey=https://adoptopenjdk.jfrog.io/adoptopenjdk/api/gpg/key/public


### PR DESCRIPTION
* Moves to UBI 8 base image
* Updates Akka to latest minor upgrade
* Requirements for Red Hat Container Certification.
* [External Dockerfile](https://dmp.fabric8.io/#external-dockerfile) for JRE install

Version 1.1.0 of the image from this PR is available on [Bintray](https://bintray.com/lightbend/registry/lightbend%3Aakka-cluster-demo)
Tested w/ minikube
Passed image certification by Red Hat. 
